### PR TITLE
Added feature to sample each track

### DIFF
--- a/src/Components/Track/Track.css
+++ b/src/Components/Track/Track.css
@@ -23,7 +23,8 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    height: 72px;
+    height: auto;
+    max-width: 60%;
   }
   
   .Track-information h3 {

--- a/src/Components/Track/Track.js
+++ b/src/Components/Track/Track.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import './Track.css';
+import { TrackPlayer } from '../TrackPlayer/TrackPlayer';
 
 export class Track extends React.Component{
     constructor(props){
@@ -28,10 +29,12 @@ export class Track extends React.Component{
     render(){
         return (
             <div className="Track">
+                
                 <div className="Track-information">
                     <h3>{this.props.track.name}</h3>
                     <p>{this.props.track.artist} | {this.props.track.album} </p>
                 </div>
+                <TrackPlayer preview={this.props.preview}/>
                 {this.renderAction()}
             </div>
         )

--- a/src/Components/TrackList/TrackList.js
+++ b/src/Components/TrackList/TrackList.js
@@ -13,7 +13,8 @@ export class TrackList extends React.Component{
                                         key={track.id} 
                                         onAdd={this.props.onAdd}
                                         onRemove={this.props.onRemove}
-                                        isRemoval={this.props.isRemoval}/>
+                                        isRemoval={this.props.isRemoval}
+                                        preview={track.preview}/>
                     })
                 }
             </div>

--- a/src/Components/TrackPlayer/TrackPlayer.css
+++ b/src/Components/TrackPlayer/TrackPlayer.css
@@ -1,0 +1,16 @@
+
+  .player-action {
+    padding: .5rem;
+    font-size: 1.05rem;
+    transition: color .25s;
+    margin-right: 0.5rem;
+    width: 7rem;
+    border: 0px;
+    background-color: rgba(0, 0, 0, 0);
+    color: #fff;
+  }
+  
+  .player-action:hover {
+    color: rgba(265, 265, 265, .5);
+  }
+  

--- a/src/Components/TrackPlayer/TrackPlayer.js
+++ b/src/Components/TrackPlayer/TrackPlayer.js
@@ -1,0 +1,16 @@
+import React from "react";
+import '../../Components/TrackPlayer/TrackPlayer.css'
+
+export class TrackPlayer extends React.Component{
+    constructor(props){
+        super(props);
+    }
+
+    render(){
+        return (
+            <audio controls className="player-action">
+                <source src={this.props.preview} type="audio/mpeg"></source>
+            </audio>
+        )
+    }
+}

--- a/src/util/Spotify.js
+++ b/src/util/Spotify.js
@@ -1,10 +1,12 @@
 const appClientID = '530cd8e3ee7c404b8c0ed9501f1b67a5';
-const redirectURI = 'http://jammming_app_2023.surge.sh';
+const redirectURI = 'http://localhost:3000/';
 let accessToken;
+let tokenIsExpired;
 
 
 const Spotify = {
     getAccessToken(){
+        //If we already have an access token, we dont need to conintue
         if (accessToken){
             return accessToken;
         }
@@ -26,6 +28,8 @@ const Spotify = {
             window.location = accessURL;
         }
     },
+
+
     
     search(term){
         const accessToken = Spotify.getAccessToken();
@@ -44,7 +48,8 @@ const Spotify = {
                 name: track.name,
                 artist: track.artists[0].name,
                 album: track.album.name,
-                uri: track.uri
+                uri: track.uri, 
+                preview: track.preview_url
             }));
         })
     },
@@ -75,8 +80,15 @@ const Spotify = {
                     body: JSON.stringify({uris: trackUris})
                 });
             });
-        });
+        })
+    
+    
+        
 
+    },
+
+    async playTrack(){
+        const response = await fetch ()
     }
     
 }


### PR DESCRIPTION
This branch implements a new feature that allows the user to play a sample of each track before adding to a playlist. This did not require any new integrations with the spotify API as the JSON response from an existing GET in Spotify.js contained the required information to set this up. 

A new component TrackPlayer has been created to manage this function, and this is chained to the track.js component. 